### PR TITLE
fix: make compatible with pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "logdna-s3",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "logdna-s3",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@logdna/env-config": "^1.0.5",
-        "@logdna/logger": "^2.6.8",
+        "@logdna/logger": "^2.6.9",
         "@logdna/stdlib": "^1.1.0"
       },
       "devDependencies": {
@@ -1532,9 +1532,9 @@
       }
     },
     "node_modules/@logdna/logger": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/@logdna/logger/-/logger-2.6.8.tgz",
-      "integrity": "sha512-1Cel0qOZRRb70U+Se2S6QirUZCnjqjlQ5xw5sT44tu6n2mRyJkG+iUPmornejvYv5fBCCufTD+i2h64G5RAGZA==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@logdna/logger/-/logger-2.6.9.tgz",
+      "integrity": "sha512-UoDR8h9/PX7xyqUNDz350VYEzFyekBD/EdZ2cTNv1RrCyQNqvF2jZ15Xq0VcOyViE7zhWWuUkRaiz9dVZ9Fejw==",
       "dependencies": {
         "@logdna/stdlib": "^1.2.3",
         "agentkeepalive": "^4.1.3",
@@ -13990,9 +13990,9 @@
       "integrity": "sha512-hs05gK5i2MVz1A95Fx+NzzeKxSSWqlJQTB7w5MiALaRnwvFvnXJxmaUuTiJM7lK7ESW4hxsjcZgCNnE0lXRvFw=="
     },
     "@logdna/logger": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/@logdna/logger/-/logger-2.6.8.tgz",
-      "integrity": "sha512-1Cel0qOZRRb70U+Se2S6QirUZCnjqjlQ5xw5sT44tu6n2mRyJkG+iUPmornejvYv5fBCCufTD+i2h64G5RAGZA==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@logdna/logger/-/logger-2.6.9.tgz",
+      "integrity": "sha512-UoDR8h9/PX7xyqUNDz350VYEzFyekBD/EdZ2cTNv1RrCyQNqvF2jZ15Xq0VcOyViE7zhWWuUkRaiz9dVZ9Fejw==",
       "requires": {
         "@logdna/stdlib": "^1.2.3",
         "agentkeepalive": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@logdna/env-config": "^1.0.5",
-    "@logdna/logger": "^2.6.8",
+    "@logdna/logger": "^2.6.9",
     "@logdna/stdlib": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrage to latest node-logger that uses apiKey
for auth - which is compatible with pipeline and
log analysis.

Ref: LOG-20186